### PR TITLE
fix suggested command to set gh version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -46,7 +46,7 @@ install_github_cli() {
   echo "Cleaning tmps..."
   rm -r $tmp_path $tmp_bin_path
 
-  echo "Run: asdf current github-cli ${version}"
+  echo "Run: asdf <global | local> github-cli ${version}"
   chmod +x $bin_path
 }
 


### PR DESCRIPTION
Noticed the output at the end of an `install` prompts the user to run `asdf current github-cli <version>`, they should instead run `asdf local|global` 