### PR TITLE
fix: support arm arch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: gh --version
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v2
+        uses: asdf-vm/actions/plugin-test@v2.1.0
         with:
           command: gh --version
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/install
+++ b/bin/install
@@ -8,6 +8,30 @@ TMPDIR=${TMPDIR:-/tmp}
 [ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
 [ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
 
+get_arch() {
+  local machine_hardware_name="$(uname -m)"
+
+  case "$machine_hardware_name" in
+    'x86_64') local arch="amd64" ;;
+    'powerpc64le' | 'ppc64le') local arch="ppc64le" ;;
+    'aarch64') local arch="arm64" ;;
+    'armv7l') local arch="arm" ;;
+    *) local arch="$machine_hardware_name" ;;
+  esac
+
+  echo "${arch}"
+}
+
+get_ext() {
+  local ext="tar.gz"
+  local version_as_number=$(echo "$version" | tr -d .)
+  if [ ${version_as_number} -ge 2280 ]; then
+    local ext="zip"
+  fi
+
+  echo "${ext}"
+}
+
 install_github_cli() {
   local install_type=$1
   local version=$2
@@ -15,13 +39,15 @@ install_github_cli() {
 
   local bin_install_path="$install_path/bin"
   local bin_path="${bin_install_path}/gh"
+  local arch="$(get_arch)"
+  local ext="$(get_ext)"
 
   case $(uname | tr '[:upper:]' '[:lower:]') in
     linux*)
-      local platform=linux_amd64
+      local platform="linux_${arch}"
       ;;
     darwin*)
-      local platform=macOS_amd64
+      local platform="macOS_${arch}"
       ;;
     *)
       local platform=notset
@@ -30,7 +56,7 @@ install_github_cli() {
 
   local filename="gh_${version}_${platform}"
   local download_url="$(get_download_url $filename)"
-  local tmp_bin_path="${TMPDIR}/${filename}.tar.gz"
+  local tmp_bin_path="${TMPDIR}/${filename}.${ext}"
   local tmp_path="${TMPDIR}/${filename}"
 
   echo "Downloading github-cli from ${download_url}"
@@ -52,7 +78,7 @@ install_github_cli() {
 
 get_download_url() {
   local filename="$1"
-  echo "https://github.com/cli/cli/releases/download/v${version}/${filename}.tar.gz"
+  echo "https://github.com/cli/cli/releases/download/v${version}/${filename}.${ext}"
 }
 
 install_github_cli $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/install
+++ b/bin/install
@@ -52,7 +52,7 @@ install_github_cli() {
       ;;
     *)
       local platform=notset
-      local ext="tar.gz"
+      local ext=notset
       ;;
   esac
 

--- a/bin/install
+++ b/bin/install
@@ -40,17 +40,19 @@ install_github_cli() {
   local bin_install_path="$install_path/bin"
   local bin_path="${bin_install_path}/gh"
   local arch="$(get_arch)"
-  local ext="$(get_ext)"
 
   case $(uname | tr '[:upper:]' '[:lower:]') in
     linux*)
       local platform="linux_${arch}"
+      local ext="tar.gz"
       ;;
     darwin*)
       local platform="macOS_${arch}"
+      local ext="$(get_ext)"
       ;;
     *)
       local platform=notset
+      local ext="tar.gz"
       ;;
   esac
 


### PR DESCRIPTION
- Add support for arm architecture
- gh-cli after version 2.28.0 uses zip and not tar.gz  https://github.com/cli/cli/releases/tag/v2.28.0
- Update actions/plugin-test to v2.1.0 