### PR TITLE
Adding Support for ARM and MacOS >= 2.28.0

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -43,7 +43,17 @@ install_github_cli() {
     local archive_type=tar.gz
     ;;
   macOS)
-    local archive_type=zip
+    # Starting with v2.28.0, the macOS binaries are distributed as zip archives.
+    local major
+    local minor
+    major=$(echo "$version" | cut -d. -f1)
+    minor=$(echo "$version" | cut -d. -f2)
+
+    if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 28 ]; }; then
+      local archive_type=zip
+    else
+      local archive_type=tar.gz
+    fi
     ;;
   *)
     local archive_type=notset

--- a/bin/install
+++ b/bin/install
@@ -3,56 +3,93 @@
 set -e
 set -o pipefail
 
-ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
 TMPDIR=${TMPDIR:-/tmp}
-[ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
-[ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
+[ -n "$ASDF_INSTALL_VERSION" ] || (echo >&2 'Missing ASDF_INSTALL_VERSION' && exit 1)
+[ -n "$ASDF_INSTALL_PATH" ] || (echo >&2 'Missing ASDF_INSTALL_PATH' && exit 1)
 
 install_github_cli() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
+  local version=$1
+  local install_path=$2
 
   local bin_install_path="$install_path/bin"
   local bin_path="${bin_install_path}/gh"
 
   case $(uname | tr '[:upper:]' '[:lower:]') in
-    linux*)
-      local platform=linux_amd64
-      ;;
-    darwin*)
-      local platform=macOS_amd64
-      ;;
-    *)
-      local platform=notset
-      ;;
+  linux*)
+    local platform=linux
+    ;;
+  darwin*)
+    local platform=macOS
+    ;;
+  *)
+    local platform=notset
+    ;;
   esac
 
-  local filename="gh_${version}_${platform}"
-  local download_url="$(get_download_url $filename)"
-  local tmp_bin_path="${TMPDIR}/${filename}.tar.gz"
+  case $(uname -m | tr '[:upper:]' '[:lower:]') in
+  x86_64)
+    local arch=amd64
+    ;;
+  arm64)
+    local arch=arm64
+    ;;
+  *)
+    local arch=notset
+    ;;
+  esac
+
+  case "$platform" in
+  linux)
+    local archive_type=tar.gz
+    ;;
+  macOS)
+    local archive_type=zip
+    ;;
+  *)
+    local archive_type=notset
+    ;;
+  esac
+
+  local filename="gh_${version}_${platform}_${arch}"
+  local download_url
+  download_url="$(get_download_url "$version" "$filename" "$archive_type")"
+  local tmp_bin_path="${TMPDIR}/${filename}.${archive_type}"
   local tmp_path="${TMPDIR}/${filename}"
 
   echo "Downloading github-cli from ${download_url}"
-  mkdir -p $bin_install_path
-  curl -sL $download_url -o $tmp_bin_path
+  mkdir -p "$bin_install_path"
+  curl -sL "$download_url" -o "$tmp_bin_path"
 
   echo "Extracting ${tmp_bin_path}"
-  tar -zxf $tmp_bin_path --directory $TMPDIR
+
+  case "$archive_type" in
+  tar.gz)
+    tar -zxf "$tmp_bin_path" --directory "$TMPDIR"
+    ;;
+  zip)
+    unzip -q "$tmp_bin_path" -d "$TMPDIR"
+    ;;
+  *)
+    echo "Unknown archive type: ${archive_type}"
+    exit 1
+    ;;
+  esac
 
   echo "Moving bin to ${bin_path}"
-  cp $tmp_path/bin/gh $bin_path
+  cp "$tmp_path"/bin/gh "$bin_path"
 
   echo "Cleaning tmps..."
-  rm -r $tmp_path $tmp_bin_path
+  rm -r "$tmp_path" "$tmp_bin_path"
 
   echo "Run: asdf <global | local> github-cli ${version}"
-  chmod +x $bin_path
+  chmod +x "$bin_path"
 }
 
 get_download_url() {
-  local filename="$1"
-  echo "https://github.com/cli/cli/releases/download/v${version}/${filename}.tar.gz"
+  local version="$1"
+  local filename="$2"
+  local archive_type="$3"
+  echo "https://github.com/cli/cli/releases/download/v${version}/${filename}.${archive_type}"
 }
 
-install_github_cli $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+install_github_cli "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Adds support for ARM binaries, and accounts for the breaking change to the release assets in [2.28.0](https://github.com/cli/cli/releases/tag/v2.28.0), where MacOS assets are zip archived.

Please forgive the extra tweaks from Shellcheck linting.